### PR TITLE
fix: add manual `Update Timesheet into Salary Slips` action; expose server method; remove on_submit hook

### DIFF
--- a/nl_attendance_timesheet/controllers/add_attendance_to_salary_slip.py
+++ b/nl_attendance_timesheet/controllers/add_attendance_to_salary_slip.py
@@ -14,9 +14,10 @@ overtime_15 = frappe.db.get_single_value(SETTINGS_DOCTYPE, "overtime_15_activity
 overtime_20 = frappe.db.get_single_value(SETTINGS_DOCTYPE, "overtime_20_activity")
 
 
-def add_attendance_data(doc, method=None):
+@frappe.whitelist()
+def add_attendance_data(payroll_entry):
     salary_slips = frappe.db.get_all(
-        "Salary Slip", filters={"payroll_entry": doc.name, "docstatus": 0}
+        "Salary Slip", filters={"payroll_entry": payroll_entry, "docstatus": 0}
     )
 
     for entry in salary_slips:
@@ -133,6 +134,10 @@ def add_attendance_data(doc, method=None):
         ):
             salary_slip.save(ignore_permissions=True)
             frappe.db.commit()
+
+    frappe.response["message"] = _(
+        "Attendance and Overtime added to Salary Slips successfully."
+    )
 
 
 def get_holiday_dates(employee):

--- a/nl_attendance_timesheet/hooks.py
+++ b/nl_attendance_timesheet/hooks.py
@@ -130,11 +130,11 @@ doctype_js = {
 # ---------------
 # Hook on document methods and events
 
-doc_events = {
-    "Payroll Entry": {
-        "on_submit": "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
-    }
-}
+# doc_events = {
+#     "Payroll Entry": {
+#         "on_submit": "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
+#     }
+# }
 
 # Scheduled Tasks
 # ---------------

--- a/nl_attendance_timesheet/public/js/payroll_entry.js
+++ b/nl_attendance_timesheet/public/js/payroll_entry.js
@@ -1,0 +1,33 @@
+frappe.ui.form.on("Payroll Entry", {
+  refresh: function (frm) {
+    if (frm.doc.salary_slips_created && frm.doc.status !== "Queued") {
+      frm.add_custom_button(
+        __("Update Timesheet into Salary Slips"),
+        function () {
+          fetch_attendance_data(frm);
+        }
+      );
+    }
+  },
+});
+
+function fetch_attendance_data(frm) {
+  frappe.call({
+    method:
+      "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
+    args: {
+      payroll_entry: frm.doc.name,
+    },
+    freeze: true,
+    freeze_message: __("Updating Timesheet Data..."),
+    callback: function (r) {
+      if (r.message) {
+        frappe.show_alert({
+          message: r.message,
+          indicator: "green",
+        });
+        frm.reload_doc();
+      }
+    },
+  });
+}


### PR DESCRIPTION
- Add client-side button on Payroll Entry to manually update Attendance/Overtime into Salary Slips after slips are created (public/js/payroll_entry.js).
  - Button shows when salary_slips_created is true and status is not "Queued".
  - Calls server method, shows progress, alerts on success, and reloads the document.

- Convert add_attendance_data to a whitelisted server method callable from the client (controllers/add_attendance_to_salary_slip.py)

Why:
- Prevent implicit side effects on submit; previous on_submit doesn't work when salary slip creation is queued
- Allow re-running the update if needed and provide user feedback in the UI.