### PR TITLE
feat(payroll): add manual button to fetch attendance and overtime data into salary slips

### DIFF
--- a/nl_attendance_timesheet/controllers/add_attendance_to_salary_slip.py
+++ b/nl_attendance_timesheet/controllers/add_attendance_to_salary_slip.py
@@ -14,9 +14,10 @@ overtime_15 = frappe.db.get_single_value(SETTINGS_DOCTYPE, "overtime_15_activity
 overtime_20 = frappe.db.get_single_value(SETTINGS_DOCTYPE, "overtime_20_activity")
 
 
-def add_attendance_data(doc, method=None):
+@frappe.whitelist()
+def add_attendance_data(payroll_entry):
     salary_slips = frappe.db.get_all(
-        "Salary Slip", filters={"payroll_entry": doc.name, "docstatus": 0}
+        "Salary Slip", filters={"payroll_entry": payroll_entry, "docstatus": 0}
     )
 
     for entry in salary_slips:
@@ -133,6 +134,10 @@ def add_attendance_data(doc, method=None):
         ):
             salary_slip.save(ignore_permissions=True)
             frappe.db.commit()
+
+    frappe.response["message"] = _(
+        "Attendance and Overtime added to Salary Slips successfully."
+    )
 
 
 def get_holiday_dates(employee):

--- a/nl_attendance_timesheet/hooks.py
+++ b/nl_attendance_timesheet/hooks.py
@@ -130,11 +130,11 @@ doctype_js = {
 # ---------------
 # Hook on document methods and events
 
-doc_events = {
-    "Payroll Entry": {
-        "on_submit": "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
-    }
-}
+# doc_events = {
+#     "Payroll Entry": {
+#         "on_submit": "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
+#     }
+# }
 
 # Scheduled Tasks
 # ---------------

--- a/nl_attendance_timesheet/public/js/payroll_entry.js
+++ b/nl_attendance_timesheet/public/js/payroll_entry.js
@@ -1,0 +1,33 @@
+frappe.ui.form.on("Payroll Entry", {
+  refresh: function (frm) {
+    if (frm.doc.salary_slips_created && frm.doc.status !== "Queued") {
+      frm.add_custom_button(
+        __("Update Timesheet into Salary Slips"),
+        function () {
+          fetch_attendance_data(frm);
+        }
+      );
+    }
+  },
+});
+
+function fetch_attendance_data(frm) {
+  frappe.call({
+    method:
+      "nl_attendance_timesheet.controllers.add_attendance_to_salary_slip.add_attendance_data",
+    args: {
+      payroll_entry: frm.doc.name,
+    },
+    freeze: true,
+    freeze_message: __("Updating Timesheet Data..."),
+    callback: function (r) {
+      if (r.message) {
+        frappe.show_alert({
+          message: r.message,
+          indicator: "green",
+        });
+        frm.reload_doc();
+      }
+    },
+  });
+}


### PR DESCRIPTION
This pull request refactors how attendance and overtime data are added to salary slips by shifting from an automatic backend hook to a user-triggered action via the Payroll Entry UI. The changes improve user control and feedback when updating timesheet data into salary slips.

**User interface improvements:**

* Added a custom button to the `Payroll Entry` form that allows users to manually trigger the update of timesheet data into salary slips. This is done through the new `fetch_attendance_data` function in `payroll_entry.js`.

**Backend logic updates:**

* Changed the `add_attendance_data` function to be a whitelisted method that takes `payroll_entry` as an argument, allowing it to be called from the frontend and providing a success message in the response. 

**Codebase maintenance:**

* Disabled the automatic hook in `hooks.py` that previously triggered attendance data addition on payroll entry submission, making the update a manual process instead.